### PR TITLE
[LIVE-DS-430] : Return error in case of failure is encountered when XGBoost model is read from binary file or json file instead of panic & remove unreachable code

### DIFF
--- a/xgensemble_io.go
+++ b/xgensemble_io.go
@@ -3,12 +3,10 @@ package leaves
 import (
 	"bufio"
 	"fmt"
-	"math"
-	"os"
-
 	"github.com/dmitryikh/leaves/internal/xgbin"
 	"github.com/dmitryikh/leaves/internal/xgjson"
 	"github.com/dmitryikh/leaves/transformation"
+	"math"
 )
 
 func xgSplitIndex(origNode *xgbin.Node) uint32 {
@@ -252,15 +250,8 @@ func XGEnsembleFromFile(filename string, loadTransformation bool) (*Ensemble, er
 	if ensemble, err := xgEnsembleFromJsonFile(filename, loadTransformation); err == nil {
 		return ensemble, nil
 	} else {
-		panic(err)
-	}
-	reader, err := os.Open(filename)
-	if err != nil {
 		return nil, err
 	}
-	defer reader.Close()
-	bufReader := bufio.NewReader(reader)
-	return XGEnsembleFromReader(bufReader, loadTransformation)
 }
 
 func xgEnsembleFromJsonFile(filename string, loadTransformation bool) (*Ensemble, error) {


### PR DESCRIPTION
### Description

- Return error in case of failure is encountered when XGBoost model is read from binary file or json file instead of panic
- Remove unreachable code

To make LFR more resilient in context of model(s) not getting downloaded due to any issues - instead of having an alternate older model to be used I believe what we can do is to remove panic in the [model loading code in LFR](https://github.com/ShareChat/moj-feed-relevance/blob/335d7e0374f165744c17c2e34ed06de95158a387/services/livestream-feed-relevance-service/repository/predictionRepo/predictionRepo.go#L119) & in the [cloned leaves library](https://github.com/mgaiduk/leaves/blob/master/xgensemble_io.go#L255).

This would not cause any downtimes or problems in new pod(s) scaling up as the errors in ranking would be caught at ranking layer & caused Opsgenie alert for the individual model  as the [ranker failure alerts would cross threshold](https://moj-monitoring.sharechat.com/d/Qast8DF4z/livestream-feed-service-relevance-dashboard?viewPanel=27&orgId=1&from=now-24h&to=now). In case of failures for any such specific model(s) the fallback feed will be computed & send (calculated via probabilistic slot based mechanism of CGs)
Slack thread : https://sharechat.slack.com/archives/C042L190A21/p1709886439221059

[Notion Ticket ](https://www.notion.so/sharechat/LFR-remove-panic-condition-in-case-model-is-not-found-both-for-leaves-wrapper-in-LFR-XGB-predict-3338ae7fd2d94bc5832c10a1a73cedc0)